### PR TITLE
Fix galaxies label for quarkus-features.

### DIFF
--- a/galaxies/manifests/galaxies.yaml
+++ b/galaxies/manifests/galaxies.yaml
@@ -16,7 +16,7 @@ spec:
         app: galaxies-deployment
         app.kubernetes.io/name: "galaxies-deployment"
         app.kubernetes.io/layer: "quarkus"
-        app.kubernetes.io/quarkus_features: "agroal, cdi, hibernate-orm, hibernate-orm-panache, jdbc-h2, kubernetes, micrometer, mutiny, narayana-jta, resteasy, resteasy-jsonb, smallrye-context-propagation"
+        app.kubernetes.io/quarkus_features: "agroal_cdi_hibernate-orm_jdbc-h2_mutiny_narayana-jta"
         version: v1
     spec:
       volumes:


### PR DESCRIPTION
Label can only be 63 characters only and cannot have "," and spaces.