### PR TITLE
Changes to wait time during "monitoring" mode.

### DIFF
--- a/techempower/scripts/perf/tfb-run.sh
+++ b/techempower/scripts/perf/tfb-run.sh
@@ -476,9 +476,9 @@ function runIterations() {
 			echo "Deploying the application..." >> ${LOGFILE}
 			${SCRIPT_REPO}/tfb-deploy.sh --clustertype=${CLUSTER_TYPE} -s ${BENCHMARK_SERVER} -n ${NAMESPACE} -i ${SCALING} -g ${TFB_IMAGE} --dbtype=${DB_TYPE} --dbhost=${DB_HOST} --cpureq=${CPU_REQ} --memreq=${MEM_REQ} --cpulim=${CPU_LIM} --memlim=${MEM_LIM} --envoptions="${ENV_OPTIONS}" --usertunables="${OPTIONS_VAR}" --quarkustpcorethreads=${quarkustpcorethreads} --quarkustpqueuesize=${quarkustpqueuesize} --quarkusdatasourcejdbcminsize=${quarkusdatasourcejdbcminsize} --quarkusdatasourcejdbcmaxsize=${quarkusdatasourcejdbcmaxsize} --FreqInlineSize=${FreqInlineSize} --MaxInlineLevel=${MaxInlineLevel} --MinInliningThreshold=${MinInliningThreshold} --CompileThreshold=${CompileThreshold} --CompileThresholdScaling=${CompileThresholdScaling} --ConcGCThreads=${ConcGCThreads} --InlineSmallCode=${InlineSmallCode} --LoopUnrollLimit=${LoopUnrollLimit} --LoopUnrollMin=${LoopUnrollMin} --MinSurvivorRatio=${MinSurvivorRatio} --NewRatio=${NewRatio} --TieredStopAtLevel=${TieredStopAtLevel} --TieredCompilation=${TieredCompilation} --AllowParallelDefineClass=${AllowParallelDefineClass} --AllowVectorizeOnDemand=${AllowVectorizeOnDemand} --AlwaysCompileLoopMethods=${AlwaysCompileLoopMethods} --AlwaysPreTouch=${AlwaysPreTouch} --AlwaysTenure=${AlwaysTenure} --BackgroundCompilation=${BackgroundCompilation} --DoEscapeAnalysis=${DoEscapeAnalysis} --UseInlineCaches=${UseInlineCaches} --UseLoopPredicate=${UseLoopPredicate} --UseStringDeduplication=${UseStringDeduplication} --UseSuperWord=${UseSuperWord} --UseTypeSpeculation=${UseTypeSpeculation} >> ${LOGFILE}
 			# err_exit "Error: ${APP_NAME} deployment failed" >> ${LOGFILE}
+			# Add extra sleep time for the deployment to complete as few machines takes longer time.
+			sleep 180
 		fi
-		# Add extra sleep time for the deployment to complete as few machines takes longer time.
-		sleep 180
 		
 		##Debug
 		#Extra sleep time
@@ -551,8 +551,11 @@ do
 done
 
 ## Cleanup all the deployments
-${SCRIPT_REPO}/tfb-cleanup.sh -c ${CLUSTER_TYPE} -n ${NAMESPACE} >> ${LOGFILE}
-sleep 10
+# Do cleanup only if deploying is also done through this run
+if [ ${RE_DEPLOY} == "true" ]; then
+	${SCRIPT_REPO}/tfb-cleanup.sh -c ${CLUSTER_TYPE} -n ${NAMESPACE} >> ${LOGFILE}
+	sleep 10
+fi
 echo " "
 if [[ ${MODE} == "monitoring" ]]; then
 	echo "Completed monitoring metrics."


### PR DESCRIPTION
- Start the load without any wait time if started in "monitoring" mode.
- Clean up the resources only if started along with deployment. Not in "monitoring" mode.