### PR TITLE
Run load with in tfb container

### DIFF
--- a/techempower/manifests/kruize-runtimes/postgres.yaml
+++ b/techempower/manifests/kruize-runtimes/postgres.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tfb-database
+  labels:
+    app: tfb-database
+spec:
+  replicas: 1
+  selector:
+   matchLabels:
+     app: tfb-database
+  template:
+    metadata:
+      labels:
+        name: tfb-database
+        app: tfb-database
+        # Add label to the application which is used by kruize/autotune to monitor it
+        app.kubernetes.io/name: "tfb-database"
+        version: v1
+    spec:
+      containers:
+      - name: tfb-database
+        image: quay.io/kruizehub/tfb-postgres:openshift
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: POSTGRESQL_USER
+            value: benchmarkdbuser
+          - name: POSTGRESQL_PASSWORD
+            value: benchmarkdbpass
+          - name: POSTGRESQL_DATABASE
+            value: hello_world
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/sh", "-c", "sleep 10 && psql -a hello_world < /tmp/create-postgres-data.sql"]        
+        ports:
+          - containerPort: 5432
+        resources:
+          requests:
+            cpu: 2
+            memory: "1024Mi"
+          limits:
+            cpu: 2
+            memory: "1024Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tfb-database
+  labels:
+    name: tfb-database
+spec:
+    type: ClusterIP
+    selector:
+      app: tfb-database
+    ports:
+      - protocol: TCP
+        port: 5432
+        targetPort: 5432

--- a/techempower/manifests/kruize-runtimes/quarkus-resteasy-hibernate.yaml
+++ b/techempower/manifests/kruize-runtimes/quarkus-resteasy-hibernate.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tfb-qrh-sample
+  labels:
+    app: tfb-qrh-app
+spec:
+  replicas: 1
+  selector:
+   matchLabels:
+     app: tfb-qrh-deployment
+  template:
+    metadata:
+      labels:
+        name: tfb-qrh-deployment
+        app: tfb-qrh-deployment
+        # Add label to the application which is used by kruize/autotune to monitor it
+        app.kubernetes.io/name: "tfb-qrh-deployment"
+        app.kubernetes.io/layer: "quarkus"
+        version: v1
+    spec:
+      volumes:
+      - name: test-volume
+      containers:
+      - name: tfb-server
+        image: quay.io/kruizehub/tfb-qrh:1.13.2.F_et17
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: "JAVA_OPTIONS"
+            value: "-server"
+        ports:
+          - containerPort: 8080
+        resources:
+         requests:
+           cpu: 0.5
+           memory: "512Mi"
+         limits:
+           cpu: 3.5
+           memory: "2048Mi"
+        volumeMounts:
+          - name: "test-volume"
+            mountPath: "/opt/jLogs"
+      - name: loadgen
+        image: quay.io/kruizehub/tfb_hyperfoil_load:0.25.2
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sh","-c"]
+        args:
+          - |
+            echo "Waiting for TFB to be ready..."
+            for i in $(seq 1 120); do
+              if wget -qO- http://localhost:8080/plaintext > /dev/null; then
+                echo "TFB is ready"
+                break
+              fi
+              sleep 1
+            done
+
+            if ! wget -qO- http://localhost:8080/plaintext > /dev/null; then
+              echo "TFB did not become ready"
+              exit 1
+            fi
+
+            echo "Starting hyperfoil load (same as docker run)..."
+            /opt/run_hyperfoil_load.sh \
+            localhost:8080 \
+            queries?queries=20 \
+            1200 \
+            1024 \
+            8096
+            echo "wrk finished"
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tfb-qrh-service
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/path: '/q/metrics'
+  labels:
+    app: tfb-qrh-app
+spec:
+  type: NodePort
+  ports:
+    - port: 8080
+      targetPort: 8080
+      name: tfb-qrh-port
+  selector:
+    name: tfb-qrh-deployment

--- a/techempower/manifests/kruize-runtimes/service-monitor.yaml
+++ b/techempower/manifests/kruize-runtimes/service-monitor.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: tfb-qrh
+  labels:
+    team: tfb-qrh-frontend
+spec:
+  selector:
+    matchLabels:
+        app: tfb-qrh-app
+  endpoints:
+    - port: tfb-qrh-port
+      path: '/q/metrics'


### PR DESCRIPTION
In TFB benchmark, instead of running load separately from a docker image, created a container to run the load whenever the tfb-server starts.

## Summary by Sourcery

Add Kubernetes manifests to deploy the TechEmpower Quarkus RESTEasy Hibernate sample, its PostgreSQL database, and monitoring for the service.

New Features:
- Introduce a Deployment and Service for the tfb-qrh Quarkus RESTEasy Hibernate sample including an in-pod load generator sidecar container.
- Add a Deployment and ClusterIP Service for the TechEmpower benchmark PostgreSQL database.
- Add a ServiceMonitor resource to scrape metrics from the tfb-qrh service for Prometheus-compatible monitoring.