### PR TITLE
Update quarkus label in TFB benchmark

### DIFF
--- a/techempower/manifests/kruize-demos/quarkus-resteasy-hibernate.yaml
+++ b/techempower/manifests/kruize-demos/quarkus-resteasy-hibernate.yaml
@@ -16,7 +16,7 @@ spec:
         app: tfb-qrh-deployment
         # Add label to the application which is used by kruize/autotune to monitor it
         app.kubernetes.io/name: "tfb-qrh-deployment"
-        app.kubernetes.io/layer: "quarkus"
+        com.redhat.component-name: "Quarkus"
         version: v1
     spec:
       volumes:


### PR DESCRIPTION
Include Quarkus label "com.redhat.component-name: "Quarkus""  for TFB benchmark

## Summary by Sourcery

Enhancements:
- Replace the previous Kubernetes application layer label with a Red Hat component-name label for the Quarkus TFB deployment manifest.